### PR TITLE
Add plugin design plan for completion popup menu

### DIFF
--- a/.github/docs.instructions.md
+++ b/.github/docs.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "docs/**/*.md"
+---
+
+- **Leading hyphen in zsh function/file names** (e.g., `-zcm-compadd.zsh`): This is an intentional zsh plugin convention for internal/private functions. The underscore prefix (`_`) is reserved by zsh for completion functions. Do not suggest renaming these to underscore prefixes.

--- a/.github/zsh.instructions.md
+++ b/.github/zsh.instructions.md
@@ -1,0 +1,5 @@
+---
+applyTo: "**/*.zsh"
+---
+
+- **Leading hyphen in function/file names** (e.g., `-zcm-compadd`): This is an intentional zsh plugin convention for internal/private functions. The underscore prefix (`_`) is reserved by zsh for completion functions and must not be used for non-completion internal functions. Do not suggest renaming hyphen-prefixed names to underscore-prefixed names.

--- a/docs/plans/todo/2026-03-07-design-completion-popup-plugin.md
+++ b/docs/plans/todo/2026-03-07-design-completion-popup-plugin.md
@@ -70,7 +70,9 @@ On plugin load (`zcm-enable`):
 1. Save current Tab binding and create a frozen copy:
    `zle -A $orig_widget .zcm-orig-$orig_widget`
 1. Bind Tab to `zcm-complete` in both emacs and viins keymaps
-1. Hook `compadd` by replacing it with `-zcm-compadd`
+1. Hook `compadd` by defining a shell function named `compadd` that shadows the
+   builtin; this function delegates to `-zcm-compadd` for capture and uses
+   `builtin compadd` for the real builtin call
 1. Hook `_main_complete` by wrapping it with `-zcm-complete`
 1. Save and set `zstyle ':completion:*' list-grouped false` (handle grouping
    ourselves; the original value is restored by `zcm-disable`)
@@ -437,7 +439,7 @@ sufficient for v1.
    parsing complexity (see conversation notes for full analysis)
 1. **recursive-edit over blocking read loop**: works within zle's event model
    correctly, no busy-waiting or async complexity
-1. **tmux-only**: uses `tmux capture-pane` for pixel-perfect screen save/restore;
+1. **tmux-only**: uses `tmux capture-pane` for character-perfect screen save/restore;
    non-tmux support deferred (would require `zle reset-prompt` fallback with
    imperfect restore of content above the prompt)
 1. **Stable candidate ids**: selection and apply are keyed by captured candidate


### PR DESCRIPTION
## Summary

- Add comprehensive design plan for the zsh-completion-menu plugin, covering interception layer (compadd wrapping, candidate capture), presentation layer (popup rendering, navigation, filtering), and file organization
- Document key architecture decisions: compadd interception over proxy PTY, recursive-edit for navigation, tmux capture-pane for screen save/restore, DSR-based cursor positioning with safe fallback
- Include risks and mitigations table and a detailed verification plan with must-pass manual tests

## Test plan

- [ ] Review the design plan for completeness and feasibility
- [ ] Validate that the architecture decisions align with the target environment (zsh 5.9, tmux)
