### PR TITLE
chore: migrate to gh-actions reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,56 +24,10 @@ permissions:
   contents: read
 
 jobs:
-  lint-markdown:
-    name: Lint Markdown
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+  text-lint:
+    uses: cboone/gh-actions/.github/workflows/text-lint.yml@main
+    with:
+      run-cspell: true
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Run markdownlint
-        run: npx markdownlint-cli2@0.21.0 "**/*.md"
-
-  format:
-    name: Check formatting
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Check formatting
-        run: npx prettier@3.8.1 --check .
-
-  spell:
-    name: Spell check
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run cspell
-        uses: streetsidesoftware/cspell-action@v6
-
-  actionlint:
-    name: Lint GitHub Actions
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+  github-lint:
+    uses: cboone/gh-actions/.github/workflows/github-lint.yml@main


### PR DESCRIPTION
## Summary

- Replace `streetsidesoftware/cspell-action@v6` with centralized `text-lint.yml` reusable workflow (includes cspell, markdownlint, prettier)
- Replace `raven-actions/actionlint@v2` with centralized `github-lint.yml` reusable workflow

## Test plan

- [ ] Verify markdownlint, prettier, and cspell run successfully via text-lint.yml
- [ ] Verify actionlint runs successfully via github-lint.yml