### PR TITLE
chore: pin gh-actions to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ permissions:
 
 jobs:
   text-lint:
-    uses: cboone/gh-actions/.github/workflows/text-lint.yml@main
+    uses: cboone/gh-actions/.github/workflows/text-lint.yml@v1
     with:
       run-cspell: true
 
   github-lint:
-    uses: cboone/gh-actions/.github/workflows/github-lint.yml@main
+    uses: cboone/gh-actions/.github/workflows/github-lint.yml@v1
 
   test:
     name: Test


### PR DESCRIPTION
## Summary

- Pin `cboone/gh-actions` references from `@main` to `@v1`

The gh-actions repo has been tagged with v1.0.0. Using the floating `@v1` tag ensures we automatically pick up non-breaking updates while maintaining stability.