### PR TITLE
Exclude .md from Prettier, rely on markdownlint-cli2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
-CHANGELOG.md
+# Markdown (formatted by markdownlint-cli2, not Prettier)
+*.md
+
 tests/


### PR DESCRIPTION
## Summary

- Exclude `*.md` from Prettier since it normalizes ordered lists to `1.` with no config option to disable
- markdownlint-cli2 `--fix` already handles markdown formatting
- Replaces previous `CHANGELOG.md`-only exclusion with blanket `*.md`