### PR TITLE
chore: pin gh-actions to v2.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   text-lint:
-    uses: cboone/gh-actions/.github/workflows/text-lint.yml@v1
+    uses: cboone/gh-actions/.github/workflows/text-lint.yml@v2.1.2
     with:
       run-cspell: true
 
@@ -69,7 +69,7 @@ jobs:
         run: make check-zsh
 
   test-scrut:
-    uses: cboone/gh-actions/.github/workflows/scrut.yml@v1
+    uses: cboone/gh-actions/.github/workflows/scrut.yml@v2.1.2
     with:
       scrut-shell: zsh
       scrut-test-dir: "tests/scrut/"

--- a/.github/workflows/github-lint.yml
+++ b/.github/workflows/github-lint.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   github-lint:
-    uses: cboone/gh-actions/.github/workflows/github-lint.yml@v1
+    uses: cboone/gh-actions/.github/workflows/github-lint.yml@v2.1.2


### PR DESCRIPTION
Pin all `cboone/gh-actions` workflow and action references from floating
tags (`@v1`, `@v2`) to the exact version `@v2.1.2`.

Part of the migration to exact-version-only tagging (cboone/gh-actions#25).
After all consuming repos are updated, the floating `v1` and `v2` tags
will be deleted from the gh-actions remote.